### PR TITLE
OurGhaza

### DIFF
--- a/martyr_search_tool/main.py
+++ b/martyr_search_tool/main.py
@@ -6,11 +6,16 @@ import argparse
 import asyncio
 import logging as log
 from itertools import chain
-from typing import Final, List
+from typing import Any, Dict, Final, List
 
 import tabulate
 
-from martyr_search_tool.sites import airwars, aitnumbers, let_them_grow_up
+from martyr_search_tool.sites import (
+    airwars,
+    aitnumbers,
+    let_them_grow_up,
+    our_ghaza,
+)
 from martyr_search_tool.sites.base_site import SearchResult
 
 Logger: Final[log.Logger] = log.getLogger(__name__)
@@ -19,10 +24,11 @@ SearchSites: List = [
     airwars.AirWars(),
     aitnumbers.AintNumbers(),
     let_them_grow_up.LetThemGrowUp(),
+    our_ghaza.OurGhaza(),
 ]
 
 
-def print_results(results: List[SearchResult]) -> None:
+async def print_results(results: List[SearchResult]) -> None:
     """Prints search results to the console in a table format.
 
     :param results: A list of search results
@@ -44,36 +50,93 @@ def print_results(results: List[SearchResult]) -> None:
     print(f"total matches: {total_matches}")
 
 
-async def main(args: List[str]) -> None:
-    arg_parser = argparse.ArgumentParser(
+async def configure_logging(enable_debug: bool = False) -> None:
+    """Configure logging for the application. By default, the logging level is
+    INFO. If enable_debug is True, the logging level is set to DEBUG.
+
+    :param enable_debug: Enable debug logging
+    :type enable_debug: bool
+    :return: None
+    """
+    if enable_debug:
+        log_level = log.DEBUG
+    else:
+        log_level = log.INFO
+
+    log.basicConfig(
+        stream=sys.stdout,
+        level=log_level,
+        format="%(levelname)s:%(name)s:%(lineno)d:%(message)s",
+    )
+
+
+async def search_names(names: List[str]) -> List[SearchResult]:
+    """Search list of sites in SearchSite for the given names.
+
+    :param names: A list of names
+    :type names: List[str]
+    :return: A list of SearchResult that contains the results of the search
+    for each site.
+    :rtype: List[SearchResult]
+    """
+    tasks = [site.search_names(names) for site in SearchSites]
+    search_results: List[List[SearchResult]] = await asyncio.gather(*tasks)
+    return list(chain(*search_results))
+
+
+def configure_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
         description="A command line tool that searches multiple sites related "
         "to the attacks of the Israeli apartheid on Palestinian "
         "civilians for martyr names",
     )
 
-    arg_parser.add_argument(
+    parser.add_argument(
         "names",
         help="""The name of the martyr to search for, the name is case
-        insensitive. If the name contains multiple words, it should be enclosed
-        in double quotes. For example, "Lian Hussein".""",
+            insensitive. If the name contains multiple words, it should be 
+            enclosed in double quotes. For example, "Lian Hussein".""",
         type=str,
         nargs="+",
         action="store",
     )
 
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="print debugging information",
+    )
+
+    return parser
+
+
+def parse_args(args: List[str]) -> Dict[str, Any]:
+    """Parse arguments from a list and return the positional and optional
+    arguments as a dictionary.
+
+    Example:
+    >>> parse_args(['--verbose', 'Lian Hussein'])
+    {'verbose': True, 'names': ['Lian Hussein']}
+
+    :param args: A list of arguments
+    :type args: List[str]
+    :return: A dictionary of arguments
+    :rtype: Dict[str, Any]
+    """
+    arg_parser: argparse.ArgumentParser = configure_parser()
     args = arg_parser.parse_args(args)
-    tasks = [site.search_names(args.names) for site in SearchSites]
-    search_results = await asyncio.gather(*tasks)
-    print_results(list(chain(*search_results)))
+    return vars(args)
+
+
+async def main(args: List[str]) -> None:
+    args = parse_args(args)
+    await configure_logging(args["verbose"])
+    search_results: List[SearchResult] = await search_names(args["names"])
+    await print_results(search_results)
 
 
 if __name__ == "__main__":
     import sys
-
-    log.basicConfig(
-        stream=sys.stdout,
-        level=log.INFO,
-        format="%(levelname)s:%(name)s:%(lineno)d:%(message)s",
-    )
 
     asyncio.run(main(sys.argv[1:]))

--- a/martyr_search_tool/sites/our_ghaza.py
+++ b/martyr_search_tool/sites/our_ghaza.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+# ourgaza.com
+
+The site is a bit similar to aintnumbers, in that it contains article about
+martyrs in Gaza under the ourgaza.com/martyrs page, but it doesn't have a
+search functionality. However, it has a filter for teens, children, adults,
+and seniors to filter out displayed articles.
+
+The site has pagination, each page has 20 articles.
+Each article is named after the martyr, so searching for a name in a list of
+articles is straight forward.
+
+- Pattern for all articles:
+    https://ourgaza.com/martyrs/{page_number}
+- Pattern for articles filtered for teen martyrs:
+    https://ourgaza.com/martyrs/filter/teen/{page}
+- Pattern for articles filtered for children martyrs:
+    https://ourgaza.com/martyrs/filter/children/{page}
+
+## Strategy
+
+1. Get the first page that contains all articles:
+    https://ourgaza.com/martyrs/1,
+    page_number=1
+2. search for an article that contains the name.
+3. Increment page_number, and repeat from step 1 till we get a 404 Error.
+
+"""
+import asyncio
+from itertools import chain
+from typing import List
+
+from martyr_search_tool.sites import base_site
+from martyr_search_tool.sites.base_site import SearchResult
+
+
+class _OurGhazaFirstPage(base_site.CurlGrepSite):
+    Name: str = "OurGaza"
+    HomePage: str = "https://ourgaza.com/"
+    QueryTemplate: str = "https://ourgaza.com/martyrs"
+
+
+class _OurGhazaPages(base_site.PaginatedSite):
+    Name: str = "OurGaza"
+    HomePage: str = "https://ourgaza.com/"
+    QueryTemplate: str = "https://ourgaza.com/martyrs/{page}"
+
+
+class OurGhaza(base_site.BaseSite):
+    Name: str = "OurGaza"
+    HomePage: str = "https://ourgaza.com/"
+    QueryTemplate: str = "https://ourgaza.com/martyrs/{page}"
+
+    def __init__(self, *args, **kwargs):
+        self.sites = [_OurGhazaFirstPage(), _OurGhazaPages()]
+
+    async def search_setup(self):
+        await asyncio.gather(*[site.search_setup() for site in self.sites])
+        self.sites[1].page = 2
+
+    async def search_teardown(self):
+        await asyncio.gather(*[site.search_teardown() for site in self.sites])
+
+    async def search_name(self, martyr_name: str) -> List[SearchResult]:
+        search_results: List[List[SearchResult]] = await asyncio.gather(
+            *[site.search_name(martyr_name) for site in self.sites]
+        )
+
+        return list(chain(*search_results))
+
+
+if __name__ == "__main__":
+    ...


### PR DESCRIPTION
# ourgaza.com

The site is a bit similar to aintnumbers, in that it contains article about martyrs in Gaza under the ourgaza.com/martyrs page, but it doesn't have a search functionality. However, it has a filter for teens, children, adults, and seniors to filter out displayed articles.

The site has pagination, each page has 20 articles. Each article is named after the martyr, so searching for a name in a list of articles is straight forward.

    - Pattern for all articles: https://ourgaza.com/martyrs/{page_number}
    - Pattern for articles filtered for teen martyrs: https://ourgaza.com/martyrs/filter/teen/{page_number}
    - Pattern for articles filtered for children martyrs: https://ourgaza.com/martyrs/filter/children/{page_number}

## Strategy

    1. Get the first page that contains all articles: https://ourgaza.com/martyrs/1, page_number=1
    2. search for an article that contains the name.
    3. Increment page_number, and repeat from step 1 till we get a 404 Error.

